### PR TITLE
Stop Spraying on Lockout

### DIFF
--- a/cmespray.sh
+++ b/cmespray.sh
@@ -22,7 +22,7 @@ checkpwns () {
     else
         echo "[-] No successful logins."
     fi
-    cat cmespray_output.txt | grep "LOCKOUT" 2>/dev/null
+    cat cmespray_output.txt | grep "STATUS_ACCOUNT_LOCKED_OUT" 2>/dev/null
     if [ $? == 0 ]; then
         echo "[!] LOCKOUT DETECTED. EXITING."
         exit


### PR DESCRIPTION
Crackmapexec doesn't state "LOCKOUT" string when a lockout occurs, but "STATUS_ACCOUNT_LOCKED_OUT".
This change should immediatelly stop the tool from spraying when a lockout occurs.